### PR TITLE
Implement basic expense tracker class

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ A simple but effective expense tracker where users can add expenses, categorize 
 
 ## Usage
 
-The repository contains a basic TypeScript project setup. To build the project, install dependencies and run the build script:
+The repository contains a basic TypeScript project. After installing dependencies and running the build script, you can execute the example application:
 
 ```bash
 npm install
 npm run build
+npm start
 ```
 
-This will compile the TypeScript source from `src/` into JavaScript in the `dist/` directory. The application entry point is `src/index.ts`.
+Running `npm start` will execute the compiled JavaScript in `dist/index.js`, which demonstrates adding an expense and printing a summary.

--- a/src/expense.ts
+++ b/src/expense.ts
@@ -1,0 +1,6 @@
+export interface Expense {
+  amount: number;
+  description: string;
+  category: string;
+  date: Date;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,17 @@
-console.log('Expense Tracker project initialized.');
+import { Expense } from './expense';
+import { ExpenseTracker } from './tracker';
+
+const tracker = new ExpenseTracker();
+
+// Example usage
+const expense: Expense = {
+  amount: 50,
+  description: 'Groceries',
+  category: 'Food',
+  date: new Date(),
+};
+
+tracker.addExpense(expense);
+
+console.log('Total expenses:', tracker.getTotal());
+console.log('Summary by category:', tracker.getSummaryByCategory());

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,0 +1,24 @@
+import { Expense } from './expense';
+
+export class ExpenseTracker {
+  private expenses: Expense[] = [];
+
+  addExpense(expense: Expense): void {
+    this.expenses.push(expense);
+  }
+
+  getExpenses(): Expense[] {
+    return [...this.expenses];
+  }
+
+  getTotal(): number {
+    return this.expenses.reduce((sum, e) => sum + e.amount, 0);
+  }
+
+  getSummaryByCategory(): Record<string, number> {
+    return this.expenses.reduce((summary, expense) => {
+      summary[expense.category] = (summary[expense.category] || 0) + expense.amount;
+      return summary;
+    }, {} as Record<string, number>);
+  }
+}


### PR DESCRIPTION
## Summary
- add expense interface
- implement `ExpenseTracker` class
- add sample usage in `index.ts`
- update README with usage instructions

## Testing
- `npm install --silent` *(fails: network access blocked)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688842d8f8ec832dbb097a23a1c68385