### PR TITLE
Enhance ExpenseTracker with filtering capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,17 @@ A simple but effective expense tracker where users can add expenses, categorize 
 - **Categorization:** Organize expenses into custom categories (e.g., food, transportation, utilities).
 - **Summary View:** See a summary of total spending by category or over a specified period.
 - **Visualization:** Optionally view charts or graphs for a quick look at spending trends.
+- **Remove and Filter Expenses:** Delete expenses by ID and filter them by category or by date range.
 
 ## Usage
 
-The repository contains a basic TypeScript project setup. To build the project, install dependencies and run the build script:
+The repository contains a basic TypeScript project. After installing dependencies and running the build script, you can execute the example application:
 
 ```bash
 npm install
 npm run build
+npm start
 ```
 
-This will compile the TypeScript source from `src/` into JavaScript in the `dist/` directory. The application entry point is `src/index.ts`.
+Running `npm start` will execute the compiled JavaScript in `dist/index.js`, which demonstrates adding an expense and printing a summary.
+You can modify `src/index.ts` to experiment with removing expenses or filtering them by category and date range.

--- a/src/expense.ts
+++ b/src/expense.ts
@@ -1,0 +1,8 @@
+export interface Expense {
+  /** Unique identifier for the expense */
+  id: string;
+  amount: number;
+  description: string;
+  category: string;
+  date: Date;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,31 @@
-console.log('Expense Tracker project initialized.');
+import { Expense } from './expense';
+import { ExpenseTracker } from './tracker';
+
+const tracker = new ExpenseTracker();
+
+// Example usage
+const expense1: Expense = {
+  id: '1',
+  amount: 50,
+  description: 'Groceries',
+  category: 'Food',
+  date: new Date(),
+};
+
+const expense2: Expense = {
+  id: '2',
+  amount: 20,
+  description: 'Bus ticket',
+  category: 'Transport',
+  date: new Date(),
+};
+
+tracker.addExpense(expense1);
+tracker.addExpense(expense2);
+
+console.log('Total expenses:', tracker.getTotal());
+console.log('Summary by category:', tracker.getSummaryByCategory());
+console.log('Total for Food:', tracker.getTotalByCategory('Food'));
+
+tracker.removeExpense('1');
+console.log('Expenses after removing id=1:', tracker.getExpenses());

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,0 +1,45 @@
+import { Expense } from './expense';
+
+export class ExpenseTracker {
+  private expenses: Expense[] = [];
+
+  addExpense(expense: Expense): void {
+    this.expenses.push(expense);
+  }
+
+  getExpenses(): Expense[] {
+    return [...this.expenses];
+  }
+
+  getTotal(): number {
+    return this.expenses.reduce((sum, e) => sum + e.amount, 0);
+  }
+
+  getSummaryByCategory(): Record<string, number> {
+    return this.expenses.reduce((summary, expense) => {
+      summary[expense.category] = (summary[expense.category] || 0) + expense.amount;
+      return summary;
+    }, {} as Record<string, number>);
+  }
+
+  removeExpense(id: string): boolean {
+    const index = this.expenses.findIndex(e => e.id === id);
+    if (index >= 0) {
+      this.expenses.splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+
+  getExpensesByCategory(category: string): Expense[] {
+    return this.expenses.filter(e => e.category === category);
+  }
+
+  getExpensesByDateRange(start: Date, end: Date): Expense[] {
+    return this.expenses.filter(e => e.date >= start && e.date <= end);
+  }
+
+  getTotalByCategory(category: string): number {
+    return this.getExpensesByCategory(category).reduce((sum, e) => sum + e.amount, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- expand `Expense` with an `id`
- implement methods in `ExpenseTracker` for removing and filtering expenses
- update example usage to demonstrate new features
- document removal and filtering features in README

## Testing
- `npm run build`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_688842d8f8ec832dbb097a23a1c68385