### PR TITLE
Add CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,25 @@ npm start
 ```
 
 Running `npm start` will execute the compiled JavaScript in `dist/index.js`, which demonstrates adding an expense and printing a summary.
+
+## Running Tests
+
+Unit tests are written using Jest. After installing dependencies you can run:
+
+```bash
+npm test
+```
+
+## Command Line Interface
+
+A simple CLI is available to manage expenses. You can run it with:
+
+```bash
+npm run cli -- <command>
+```
+
+Commands available:
+
+- `add <amount> <description> <category>` - Add a new expense
+- `list` - List all added expenses in the current session
+- `summary` - Display total spent per category

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests']
+};

--- a/package.json
+++ b/package.json
@@ -5,12 +5,21 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "jest",
+    "cli": "ts-node src/cli.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "ts-node": "^10.0.0",
+    "@types/node": "^18.0.0"
+  },
+  "dependencies": {
+    "yargs": "^17.0.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,33 @@
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { ExpenseTracker } from './tracker';
+import { Expense } from './expense';
+
+const tracker = new ExpenseTracker();
+
+const argv = yargs(hideBin(process.argv))
+  .command('add <amount> <description> <category>', 'Add a new expense', y => {
+    return y
+      .positional('amount', { type: 'number', describe: 'Amount spent' })
+      .positional('description', { type: 'string', describe: 'Expense description' })
+      .positional('category', { type: 'string', describe: 'Expense category' });
+  }, args => {
+    const expense: Expense = {
+      amount: args.amount as number,
+      description: args.description as string,
+      category: args.category as string,
+      date: new Date()
+    };
+    tracker.addExpense(expense);
+    console.log('Expense added.');
+  })
+  .command('list', 'List all expenses', {}, () => {
+    console.table(tracker.getExpenses());
+  })
+  .command('summary', 'Show summary by category', {}, () => {
+    console.table(tracker.getSummaryByCategory());
+  })
+  .demandCommand()
+  .help()
+  .argv;
+

--- a/tests/tracker.test.ts
+++ b/tests/tracker.test.ts
@@ -1,0 +1,26 @@
+import { ExpenseTracker } from '../src/tracker';
+import { Expense } from '../src/expense';
+
+describe('ExpenseTracker', () => {
+  test('addExpense and getExpenses', () => {
+    const tracker = new ExpenseTracker();
+    const expense: Expense = { amount: 10, description: 'Coffee', category: 'Food', date: new Date() };
+    tracker.addExpense(expense);
+    expect(tracker.getExpenses()).toEqual([expense]);
+  });
+
+  test('getTotal', () => {
+    const tracker = new ExpenseTracker();
+    tracker.addExpense({ amount: 10, description: 'Coffee', category: 'Food', date: new Date() });
+    tracker.addExpense({ amount: 15, description: 'Taxi', category: 'Transport', date: new Date() });
+    expect(tracker.getTotal()).toBe(25);
+  });
+
+  test('getSummaryByCategory', () => {
+    const tracker = new ExpenseTracker();
+    tracker.addExpense({ amount: 10, description: 'Coffee', category: 'Food', date: new Date() });
+    tracker.addExpense({ amount: 20, description: 'Dinner', category: 'Food', date: new Date() });
+    tracker.addExpense({ amount: 15, description: 'Taxi', category: 'Transport', date: new Date() });
+    expect(tracker.getSummaryByCategory()).toEqual({ Food: 30, Transport: 15 });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,6 @@
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- add Jest configuration and test suite for `ExpenseTracker`
- implement a simple CLI using `yargs`
- document testing and CLI usage
- update TypeScript config to compile only `src`
- expand package.json scripts and dependencies

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc` *(fails: cannot find module 'yargs')*

------
https://chatgpt.com/codex/tasks/task_e_688846780ac4832da0e73a59951bdcc3