### PR TITLE
Update CLI to use compiled output

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ npm test
 
 ## Command Line Interface
 
-A simple CLI is available to manage expenses. You can run it with:
+A simple CLI is available to manage expenses. Build the project first and then run it with:
 
 ```bash
+npm run build
 npm run cli -- <command>
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "jest",
-    "cli": "ts-node src/cli.ts"
+    "cli": "node dist/cli.js"
   },
   "keywords": [],
   "author": "",
@@ -16,7 +16,6 @@
     "typescript": "^5.0.0",
     "ts-jest": "^29.0.0",
     "@types/jest": "^29.0.0",
-    "ts-node": "^10.0.0",
     "@types/node": "^18.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- run CLI from compiled JavaScript instead of ts-node
- drop the `ts-node` dev dependency
- document that CLI requires running the build first

## Testing
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68884b19db40832db90551ad25f296c4